### PR TITLE
Remove `pragma` definitions

### DIFF
--- a/erc20-wrapper/erc20-wrapper.sol
+++ b/erc20-wrapper/erc20-wrapper.sol
@@ -1,3 +1,6 @@
+// This file does not define a pragma version because it is meant to be compiled with Solang and Solang ignores
+// pragma definitions, see [here](https://solang.readthedocs.io/en/latest/language/pragmas.html).
+
 import "substrate";
 
 contract ERC20Wrapper {

--- a/price-oracle-wrapper/interfaces/IPriceOracleGetter.sol
+++ b/price-oracle-wrapper/interfaces/IPriceOracleGetter.sol
@@ -1,6 +1,5 @@
 // Based on AAVE protocol
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.8.0;
 
 /// @title IPriceOracleGetter interface
 interface IPriceOracleGetter {

--- a/price-oracle-wrapper/interfaces/IPriceOracleGetter.sol
+++ b/price-oracle-wrapper/interfaces/IPriceOracleGetter.sol
@@ -1,6 +1,9 @@
 // Based on AAVE protocol
 // SPDX-License-Identifier: GPL-3.0
 
+// This file does not define a pragma version because it is meant to be compiled with Solang and Solang ignores
+// pragma definitions, see [here](https://solang.readthedocs.io/en/latest/language/pragmas.html).
+
 /// @title IPriceOracleGetter interface
 interface IPriceOracleGetter {
     /// @dev returns the asset price in USD

--- a/price-oracle-wrapper/price-oracle-wrapper.sol
+++ b/price-oracle-wrapper/price-oracle-wrapper.sol
@@ -1,3 +1,6 @@
+// This file does not define a pragma version because it is meant to be compiled with Solang and Solang ignores
+// pragma definitions, see [here](https://solang.readthedocs.io/en/latest/language/pragmas.html).
+
 import "substrate";
 import {IPriceOracleGetter} from "./interfaces/IPriceOracleGetter.sol";
 


### PR DESCRIPTION
Instead of changing/locking the `pragma` version definitions in all contracts, this PR actually removes them. The reason is that they are not actually used in Solang, see
[here](https://solang.readthedocs.io/en/latest/language/pragmas.html). Thus, to avoid confusion I think it's better to remove them completely.

Closes #21.