### PR TITLE
Add zero-address checks to ERC20 wrapper

### DIFF
--- a/erc20-wrapper/erc20-wrapper.sol
+++ b/erc20-wrapper/erc20-wrapper.sol
@@ -72,6 +72,14 @@ contract ERC20Wrapper {
     }
 
     function transfer(address _to, uint256 _amount) public returns (bool) {
+        address from = msg.sender;
+        if (from == address(0)) {
+            revert("ERC20InvalidSender");
+        }
+        if (_to == address(0)) {
+            revert("ERC20InvalidReceiver");
+        }
+
         bytes currency = createCurrencyId();
         bytes to = abi.encode(_to);
 
@@ -102,6 +110,14 @@ contract ERC20Wrapper {
     }
 
     function approve(address _spender, uint256 _amount) public returns (bool) {
+        address owner = msg.sender;
+        if (owner == address(0)) {
+            revert("ERC20InvalidApprover");
+        }
+        if (_spender == address(0)) {
+            revert("ERC20InvalidSpender");
+        }
+
         bytes currency = createCurrencyId();
         bytes spender = abi.encode(_spender);
 


### PR DESCRIPTION
This PR adds additional checks to some functions of the ERC20 wrapper contract. The changes adhere to the implementation of [this](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/ERC20.sol) contract. Note that it's not possible to revert with custom errors in Solang on Substrate. You can only [revert with a string](https://solang.readthedocs.io/en/latest/language/builtins.html#revert-or-revert-string). That's why I decided to make the string at least have the same name as the custom errors used in [this](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/ERC20.sol) contract. 

The auditors point out that we should consider adding additional checks to basically all accessible functions. I don't think this makes sense. I also checked if Aaves implementation of the `IPriceOracleGetter` interface has any zero-address checks and there is only one, [here](https://github.com/aave/aave-protocol/blob/4b4545fb583fd4f400507b10f3c3114f45b8a037/contracts/misc/ChainlinkProxyPriceProvider.sol#L74), which then uses some fallback oracle. Since we don't have a fallback oracle I decided not to change anything.

We might want to get back to the auditors and ask them how they would expect these zero-address checks to look like for all functions.