### PR TITLE
23 fix informational issues raised in audit report

### DIFF
--- a/erc20-wrapper/ERC20Wrapper.sol
+++ b/erc20-wrapper/ERC20Wrapper.sol
@@ -45,7 +45,7 @@ contract ERC20Wrapper {
     /**
      * @dev Returns the name of the token.
      */
-    function name() public view virtual returns (string memory) {
+    function name() external view virtual returns (string memory) {
         return _name;
     }
 
@@ -53,15 +53,15 @@ contract ERC20Wrapper {
      * @dev Returns the symbol of the token, usually a shorter version of the
      * name.
      */
-    function symbol() public view virtual returns (string memory) {
+    function symbol() external view virtual returns (string memory) {
         return _symbol;
     }
 
-    function decimals() public view virtual returns (uint8) {
+    function decimals() external view virtual returns (uint8) {
         return _decimals;
     }
 
-    function totalSupply() public returns (uint256) {
+    function totalSupply() external returns (uint256) {
         bytes currency = createCurrencyId();
         bytes input = currency;
 
@@ -73,7 +73,7 @@ contract ERC20Wrapper {
         return totalSupplyU256;
     }
 
-    function balanceOf(address _owner) public returns (uint256) {
+    function balanceOf(address _owner) external returns (uint256) {
         // Encode currency and address
         bytes currency = createCurrencyId();
         bytes owner = abi.encode(_owner);
@@ -88,7 +88,7 @@ contract ERC20Wrapper {
         return balanceU256;
     }
 
-    function transfer(address _to, uint256 _amount) public returns (bool) {
+    function transfer(address _to, uint256 _amount) external returns (bool) {
         address from = msg.sender;
         if (from == address(0)) {
             revert("ERC20InvalidSender");
@@ -114,7 +114,7 @@ contract ERC20Wrapper {
         return success;
     }
 
-    function allowance(address _owner, address _spender) public returns (uint256) {
+    function allowance(address _owner, address _spender) external returns (uint256) {
         bytes currency = createCurrencyId();
         bytes owner = abi.encode(_owner);
         bytes spender = abi.encode(_spender);
@@ -128,7 +128,7 @@ contract ERC20Wrapper {
         return allowanceU256;
     }
 
-    function approve(address _spender, uint256 _amount) public returns (bool) {
+    function approve(address _spender, uint256 _amount) external returns (bool) {
         address owner = msg.sender;
         if (owner == address(0)) {
             revert("ERC20InvalidApprover");
@@ -160,7 +160,7 @@ contract ERC20Wrapper {
         return success;
     }
 
-    function transferFrom(address _from, address _to, uint256 _amount) public returns (bool) {
+    function transferFrom(address _from, address _to, uint256 _amount) external returns (bool) {
         bytes from = abi.encode(_from);
         bytes currency = createCurrencyId();
         bytes to = abi.encode(_to);

--- a/erc20-wrapper/ERC20Wrapper.sol
+++ b/erc20-wrapper/ERC20Wrapper.sol
@@ -45,7 +45,7 @@ contract ERC20Wrapper {
     /**
      * @dev Returns the name of the token.
      */
-    function name() external view virtual returns (string memory) {
+    function name() external view returns (string memory) {
         return _name;
     }
 
@@ -53,11 +53,11 @@ contract ERC20Wrapper {
      * @dev Returns the symbol of the token, usually a shorter version of the
      * name.
      */
-    function symbol() external view virtual returns (string memory) {
+    function symbol() external view returns (string memory) {
         return _symbol;
     }
 
-    function decimals() external view virtual returns (uint8) {
+    function decimals() external view returns (uint8) {
         return _decimals;
     }
 

--- a/price-oracle-wrapper/PriceOracleWrapper.sol
+++ b/price-oracle-wrapper/PriceOracleWrapper.sol
@@ -27,27 +27,27 @@ contract PriceOracleWrapper is IPriceOracleGetter {
         string symbol;
     }
 
-    mapping(address => OracleKey) public _oracleByAsset;
+    mapping(address => OracleKey) public oracleByAsset;
 
     // we store _asset, _blockchain and _symbol for use by function getAssetPrice() which is called by Nabla. 
     // _blockchain and _symbol are the keys used to access a particular price feed from the chain.
     constructor(OracleKey[] oracleKeys) {
         uint oracleKeysLength = oracleKeys.length;
         for (uint i = 0; i < oracleKeysLength; i++) {
-            _oracleByAsset[oracleKeys[i].asset] = oracleKeys[i];
+            oracleByAsset[oracleKeys[i].asset] = oracleKeys[i];
         }
     }
 
     function getOracleKeyAsset(address asset) external view returns (address) {
-        return _oracleByAsset[asset].asset;
+        return oracleByAsset[asset].asset;
     }
 
     function getOracleKeyBlockchain(address asset) external view returns (string) {
-        return _oracleByAsset[asset].blockchain;
+        return oracleByAsset[asset].blockchain;
     }
 
     function getOracleKeySymbol(address asset) external view returns (string) {
-        return _oracleByAsset[asset].symbol;
+        return oracleByAsset[asset].symbol;
     }
 
     /**
@@ -56,8 +56,8 @@ contract PriceOracleWrapper is IPriceOracleGetter {
      * @return price Asset price in USD
      */
     function getAssetPrice(address asset) external returns (uint256 price) {
-        require(_oracleByAsset[asset].asset == asset, "Asset not supported");
-        price = uint256(getAnyAssetPrice(_oracleByAsset[asset].blockchain, _oracleByAsset[asset].symbol));
+        require(oracleByAsset[asset].asset == asset, "Asset not supported");
+        price = uint256(getAnyAssetPrice(oracleByAsset[asset].blockchain, oracleByAsset[asset].symbol));
     }
 
     function getAnyAssetSupply(string blockchain, string symbol) external returns (uint128 result) {

--- a/price-oracle-wrapper/PriceOracleWrapper.sol
+++ b/price-oracle-wrapper/PriceOracleWrapper.sol
@@ -42,11 +42,11 @@ contract PriceOracleWrapper is IPriceOracleGetter {
         price = uint256(getAnyAssetPrice(_oracleByAsset[asset].blockchain, _oracleByAsset[asset].symbol));
     }
 
-    function getAnyAssetSupply(string blockchain, string symbol) public returns (uint128 result) {
+    function getAnyAssetSupply(string blockchain, string symbol) external returns (uint128 result) {
         result = getAnyAsset(blockchain, symbol).supply;
     }
 
-    function getAnyAssetLastUpdateTimestamp(string blockchain, string symbol) public returns (uint64 result) {
+    function getAnyAssetLastUpdateTimestamp(string blockchain, string symbol) external returns (uint64 result) {
         result = getAnyAsset(blockchain, symbol).last_update_timestamp;
     }
 

--- a/price-oracle-wrapper/PriceOracleWrapper.sol
+++ b/price-oracle-wrapper/PriceOracleWrapper.sol
@@ -10,6 +10,23 @@ import {IPriceOracleGetter} from "./interfaces/IPriceOracleGetter.sol";
  * @dev This contract can be used with the Nabla's Router contract
  */
 contract PriceOracleWrapper is IPriceOracleGetter {
+    // The coin info returned by the chain extension call
+    struct CoinInfo {
+        bytes symbol;
+        bytes name;
+        bytes blockchain;
+        uint128 supply;
+        uint64 last_update_timestamp;
+        uint128 price;
+    }
+
+    // The mapping of an asset address with the oracles keys blockchain and symbol
+    struct OracleKey {
+        address asset;
+        string blockchain;
+        string symbol;
+    }
+
     mapping(address => OracleKey) public _oracleByAsset;
 
     // we store _asset, _blockchain and _symbol for use by function getAssetPrice() which is called by Nabla. 
@@ -85,20 +102,5 @@ contract PriceOracleWrapper is IPriceOracleGetter {
         result32 = output;
     }
 
-    // The coin info returned by the chain extension call
-    struct CoinInfo {
-        bytes symbol;
-        bytes name;
-        bytes blockchain;
-        uint128 supply;
-        uint64 last_update_timestamp;
-        uint128 price;
-    }
-
-    // The mapping of an asset address with the oracles keys blockchain and symbol
-    struct OracleKey {
-        address asset;
-        string blockchain;
-        string symbol;
-    }
+    
 }

--- a/price-oracle-wrapper/PriceOracleWrapper.sol
+++ b/price-oracle-wrapper/PriceOracleWrapper.sol
@@ -32,7 +32,8 @@ contract PriceOracleWrapper is IPriceOracleGetter {
     // we store _asset, _blockchain and _symbol for use by function getAssetPrice() which is called by Nabla. 
     // _blockchain and _symbol are the keys used to access a particular price feed from the chain.
     constructor(OracleKey[] oracleKeys) {
-        for (uint i = 0; i < oracleKeys.length; i++) {
+        uint oracleKeysLength = oracleKeys.length;
+        for (uint i = 0; i < oracleKeysLength; i++) {
             _oracleByAsset[oracleKeys[i].asset] = oracleKeys[i];
         }
     }


### PR DESCRIPTION
Closes #23

I01. Solidity Style Guide Violation: Naming mismatch - this one seems to be already fixed

Checked that modified contracts compile successfully by using solang